### PR TITLE
Eliminate warning, if swiftlint installed via brew

### DIFF
--- a/Notification Agent.xcodeproj/project.pbxproj
+++ b/Notification Agent.xcodeproj/project.pbxproj
@@ -527,7 +527,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if test -d "/opt/homebrew/bin/"; then\n  PATH="/opt/homebrew/bin/:${PATH}"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Added following lines to the "Run Script" in "Build Phases" to supress the swiftlint warning for installs via Homebrew:
```
if test -d "/opt/homebrew/bin/"; then
  PATH="/opt/homebrew/bin/:${PATH}"
fi
export PATH
```
