### PR TITLE
bugfix for issue 106, Popup doesn't resize properly when using lots of text in the Timer Accessory View

### DIFF
--- a/Shared/Views/AccessoryViews/TimerAccessoryView.swift
+++ b/Shared/Views/AccessoryViews/TimerAccessoryView.swift
@@ -29,6 +29,9 @@ final class TimerAccessoryView: AccessoryView {
             }
         }
     }
+    private var containerWidth: CGFloat {
+            return self.superview?.bounds.width ?? 0
+    }
 
     // MARK: - Initializers
 
@@ -51,6 +54,11 @@ final class TimerAccessoryView: AccessoryView {
     
     override func configureAccessibilityElements() {
         timerLabel.setAccessibilityLabel("accessory_view_accessibility_timer_label".localized)
+    }
+    
+    /// Adjust the view size based on the superview width
+    override func adjustViewSize() {
+        self.widthAnchor.constraint(equalToConstant: containerWidth).isActive = true
     }
 
     // MARK: - Private methods


### PR DESCRIPTION
The popup grows wider and wider but doesn't grow in height. The timer accessory view is not constrained to its container's width.
Added code to adjust the view based on the container's width.

*List which issues are fixed by this PR. You must list at least one issue.*
The popup now maintains width of its container. With lots of text in the timer accessory view, the popup grows in height rather than in width.
https://github.com/IBM/mac-ibm-notifications/issues/106

## Pre-launch Checklist

- [x] I read the [Code of Conduct](/CODE_OF_CONDUCT.md) and followed the process outlined there for submitting PRs.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
