### PR TITLE
Add output_file parameter for type -onboarding

### DIFF
--- a/Notification Agent Core/Controllers/HelpBuilder.swift
+++ b/Notification Agent Core/Controllers/HelpBuilder.swift
@@ -70,7 +70,8 @@ public final class HelpBuilder {
                                                 "-background_panel".yellow(),
                                                 "-unmovable".yellow(),
                                                 "-timeout".yellow(),
-                                                "-disable_quit".yellow()]
+                                                "-disable_quit".yellow(),
+                                                "-output_file".yellow()]
     static let systemAlertArguments: [String] = ["-type".green(),
                                                  "-title".yellow(),
                                                  "-subtitle".yellow(),
@@ -162,7 +163,8 @@ public final class HelpBuilder {
                                                    "[ opaque | translucent ]".red() + "\n      The style for the background panel that will cover all the screens.\n      Example: -background_panel opaque",
                                                    "\n      Flag that make the UI unmovable for the user.\n      Example: -unmovable",
                                                    "\n      The timeout for the onboarding. After this amount of seconds the agent exit with the timeout exit code.\n      Example: -timeout 300",
-                                                   "\n      Flag that tells the agent to ignore cmd+q shortcut.\n      Example: -disable_quit"]
+                                                   "\n      Flag that tells the agent to ignore cmd+q shortcut.\n      Example: -disable_quit",
+                                                   "[ filename.plist ]".red() + "\n      Flag that tells the agent the filename used to store onboarding output.\n      Example: -output_file custom.plist"]
     static let systemAlertDescriptions: [String] = ["[ systemAlert ]".red() + "\n      The UI type of the notification.\n      Example: -type systemAlert",
                                                     "\n      The title of the notification.\n      Example: -title \"Title\"",
                                                     "\n      The subtitle of the notification.\n      Example: -subtitle \"Subtitle\"",

--- a/Notification Agent Onboarding/Views/OnboardingViewModel.swift
+++ b/Notification Agent Onboarding/Views/OnboardingViewModel.swift
@@ -198,7 +198,7 @@ class OnboardingViewModel: NSObject, ObservableObject {
             plistDictionary[index.description] = pageDictionary
         }
         let dictionaryResult = NSDictionary(dictionary: plistDictionary)
-        Utils.write(dictionaryResult, to: Constants.storeFileName)
+        Utils.write(dictionaryResult, to: onboardingData.outputFile)
     }
     
     /// Update the state of the progress bar if it's set to automatic.

--- a/Shared/Model/UIObjects/NotificationObject.swift
+++ b/Shared/Model/UIObjects/NotificationObject.swift
@@ -145,6 +145,7 @@ public final class NotificationObject: NSObject, Codable, NSSecureCoding {
             switch type {
             case .onboarding:
                 self.payload = try Self.loadOnboardingPayload(payloadRawData)
+                self.payload?.outputFile = dict["output_file"] as? String ?? Constants.storeFileName
             default:
                 break
             }

--- a/Shared/Model/UIObjects/OnboardingData.swift
+++ b/Shared/Model/UIObjects/OnboardingData.swift
@@ -16,12 +16,14 @@ public final class OnboardingData: Codable {
     /// An array of pages.
     var pages: [InteractiveOnboardingPage]
     var progressBarPayload: String?
+    var outputFile: String!
     
     // MARK: - Codable protocol conformity - START
 
     enum ODCodingKeys: String, CodingKey {
         case pages
         case progressBarPayload
+        case outputFile
     }
 
     required public init(from decoder: Decoder) throws {
@@ -34,12 +36,16 @@ public final class OnboardingData: Codable {
         if let payload = try? container.decodeIfPresent(String.self, forKey: .progressBarPayload) {
             self.progressBarPayload = payload
         }
+        if let outputFile = try? container.decodeIfPresent(String.self, forKey: .outputFile) {
+            self.outputFile = outputFile
+        }
     }
 
     public  func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: ODCodingKeys.self)
         
         try container.encodeIfPresent(progressBarPayload, forKey: .progressBarPayload)
+        try container.encodeIfPresent(outputFile, forKey: .outputFile)
         try container.encode(pages, forKey: .pages)
     }
 


### PR DESCRIPTION
Adding an accepted parameter for type -onboarding to define the output file.  By defining a unique output file we may find more use cases where a generic wizard/walkthrough would be would helpful.  This was brought up in #230. 
